### PR TITLE
Allow h3:parent to return the parent at the current resolution

### DIFF
--- a/c_src/h3.c
+++ b/c_src/h3.c
@@ -307,7 +307,7 @@ erl_parent(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
         return enif_make_badarg(env);
     }
 
-    if (res >= h3GetResolution(h3idx))
+    if (res > h3GetResolution(h3idx))
     {
         // asking for a parent with a higher resolution is nonsense
         return enif_make_badarg(env);

--- a/src/h3.erl
+++ b/src/h3.erl
@@ -108,6 +108,7 @@ is_pentagon(_) ->
     not_loaded(?LINE).
 
 %% @doc Returns the parent (coarser) index containing the given Index.
+%% Requests for higher resolutions than the the resolution of `Index` are an error.
 -spec parent(Index::h3index(), ParentRes::resolution()) -> h3index().
 parent(_, _) ->
     not_loaded(?LINE).

--- a/test/h3_SUITE.erl
+++ b/test/h3_SUITE.erl
@@ -17,7 +17,8 @@
          k_ring_origin_index_test/1,
          k_ring_distance_origin_test/1,
          k_ring_distance_test/1,
-         compact_roundtrip_test/1
+         compact_roundtrip_test/1,
+         parent_test/1
         ]).
 
 all() ->
@@ -33,7 +34,8 @@ all() ->
      k_ring_origin_index_test,
      k_ring_distance_origin_test,
      k_ring_distance_test,
-     compact_roundtrip_test
+     compact_roundtrip_test,
+     parent_test
     ].
 
 init_per_testcase(_, Config) ->
@@ -154,4 +156,15 @@ compact_roundtrip_test(Config) ->
     Decompressed = h3:uncompact(Compressed, 9),
     ExpandedSize = length(Decompressed),
 
+    ok.
+
+parent_test(Config) ->
+    SunnyvaleIndex = proplists:get_value(sunnyvale_index, Config),
+    Resolutions = proplists:get_value(resolutions, Config),
+    Resolution = h3:get_resolution(SunnyvaleIndex),
+    %% check we can get the parent at the same resolution and it's the same index
+    SunnyvaleIndex = h3:parent(SunnyvaleIndex, Resolution),
+    ?assertError(badarg, h3:parent(SunnyvaleIndex, Resolution+1)),
+    [ ?assertNotException(error, badarg, h3:parent(SunnyvaleIndex, R)) || R <- Resolutions, R =< Resolution ],
+    [ ?assertError(badarg, h3:parent(SunnyvaleIndex, R)) || R <- Resolutions, R > Resolution ],
     ok.


### PR DESCRIPTION
Before this change, asking for the parent of an h3 index at the same
resolution threw an error. Instead it's more useful to allow it to
return the same index as was passed in (eg the parent of an index with
resolution 10 at resoltion 10 is the same as the index input). This
change relaxes the check and adds tests for it.