### PR TITLE
Implement getUnidirectionalEdge

### DIFF
--- a/c_src/h3.c
+++ b/c_src/h3.c
@@ -617,6 +617,29 @@ erl_indices_are_neighbors(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
                                                                   : ATOM_FALSE;
 }
 
+static ERL_NIF_TERM
+erl_get_h3_edge(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
+{
+    H3Index h3idx_origin;
+    if (!get_h3idx(env, argv[0], &h3idx_origin))
+    {
+        return enif_make_badarg(env);
+    }
+
+    H3Index h3idx_destination;
+    if (!get_h3idx(env, argv[1], &h3idx_destination))
+    {
+        return enif_make_badarg(env);
+    }
+
+    H3Index h3idx = getH3UnidirectionalEdge(h3idx_origin, h3idx_destination);
+    if (!h3UnidirectionalEdgeIsValid(h3idx))
+    {
+        return enif_make_badarg(env);
+    }
+    return make_h3idx(env, h3idx);
+}
+
 static ErlNifFunc nif_funcs[] =
     {{"num_hexagons", 1, erl_num_hexagons, 0},
      {"edge_length_meters", 1, erl_edge_length_meters, 0},
@@ -640,7 +663,8 @@ static ErlNifFunc nif_funcs[] =
      {"k_ring", 2, erl_k_ring, 0},
      {"k_ring_distances", 2, erl_k_ring_distances, 0},
      {"max_k_ring_size", 1, erl_max_k_ring_size, 0},
-     {"indices_are_neighbors", 2, erl_indices_are_neighbors, 0}};
+     {"indices_are_neighbors", 2, erl_indices_are_neighbors, 0},
+     {"h3_edge", 2, erl_get_h3_edge, 0}};
 
 #define ATOM(Id, Value)                                                        \
     {                                                                          \

--- a/src/h3.erl
+++ b/src/h3.erl
@@ -22,7 +22,8 @@
          max_k_ring_size/1,
          compact/1,
          uncompact/2,
-         indices_are_neighbors/2
+         indices_are_neighbors/2,
+         h3_edge/2
         ]).
 
 -on_load(init/0).
@@ -156,6 +157,12 @@ uncompact(_,_) ->
 
 -spec indices_are_neighbors(h3index(), h3index()) -> boolean().
 indices_are_neighbors(_, _) ->
+    not_loaded(?LINE).
+
+%% @doc Returns a unidirectiol edge based on the given origin
+%% and destination.
+-spec h3_edge(Origin::h3index(), Destination::h3index()) -> Edge::h3index().
+h3_edge(_, _) ->
     not_loaded(?LINE).
 
 init() ->

--- a/test/h3_SUITE.erl
+++ b/test/h3_SUITE.erl
@@ -13,6 +13,7 @@
          h3_to_geo_boundary_test/1,
          hex_area_km2_decreasing_test/1,
          self_not_a_neighbor_test/1,
+         h3_edge_test/1,
          h3_of_geo_coord_test/1,
          k_ring_origin_index_test/1,
          k_ring_distance_origin_test/1,
@@ -30,6 +31,7 @@ all() ->
      h3_to_geo_constrain_test,
      hex_area_km2_decreasing_test,
      self_not_a_neighbor_test,
+     h3_edge_test,
      h3_of_geo_coord_test,
      k_ring_origin_index_test,
      k_ring_distance_origin_test,
@@ -104,6 +106,13 @@ hex_area_km2_decreasing_test(Config) ->
 self_not_a_neighbor_test(_Config) ->
     SFH3 = h3:from_geo({0.659966917655, -2.1364398519396}, 9),
     false = h3:indices_are_neighbors(SFH3, SFH3),
+    ok.
+
+
+h3_edge_test(Config) ->
+    ParisIndex = proplists:get_value(paris_index, Config), 
+    NorthParisIndex = h3:from_geo({37.3715593, -122.0553238}, 7),
+    1401326775769759743 = h3:h3_edge(ParisIndex, NorthParisIndex),
     ok.
 
 h3_of_geo_coord_test(_Config) ->


### PR DESCRIPTION
This PR is to get a feel for the repository and contributing process. I would like to start expanding the API bindings if all goes well.

Implements:
`getH3UnidirectionalEdge()` binding to `h3:get_edge/2`


Would it be useful moving forward if I were to add more specific error responses instead of relying on `badarg`?


