### PR TITLE
Make this repo show up as an Erlang project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+c_src/* linguist-vendored


### PR DESCRIPTION
This PR adds a config that is known to Linguist, the project Github uses to detect/format different programming languages. This one-liner _should_ make this repo show up as an erlang project, and not c.
