### PR TITLE
Tighten-up `libh3.a` build

### DIFF
--- a/c_src/compile.sh
+++ b/c_src/compile.sh
@@ -17,11 +17,14 @@ if [ ! "$VERSION" = "$CURRENT_VERSION" ]; then
     git checkout $VERSION
 fi
 
-if [ ! -d build ]; then
-    mkdir build
-fi
-cd build
-if [ ! -f Makefile ]; then
-    cmake ..
-fi
-make -j h3
+cmake                          \
+    -H.                        \
+    -Bbuild                    \
+    -DBUILD_TESTING=OFF        \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_COVERAGE=OFF      \
+    -DENABLE_DOCS=OFF          \
+    -DENABLE_FORMAT=OFF        \
+    -DENABLE_LINTING=OFF
+
+cmake --build build --target h3


### PR DESCRIPTION
There are a few problems with how we're currently building the H3
native c library:

- it runs `clang-format` by default and modifies the source
  tree (leaving a dirty git repo)
- it runs static analysis (slow)
- it builds and runs tests
- it build without optimizations

This patch cleans that up by building `libh3.a` in `Release` mode,
turning off options that enable targets we don't need (like tests),
and only building the `h3` target.