### PR TITLE
Add github actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+    container: madninja/builder-erlang:2
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: rebar3 compile
+
+    - name: Run Dialyzer
+      run: rebar3 dialyzer
+
+    - name: Run tests
+      run: rebar3 ct
+
+    - name: Generate coverage report
+      run: rebar3 covertool generate
+
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v1.0.7
+      with:
+        file: _build/test/covertool/h3.covertool.xml
+        fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # erlang-h3
 
-[![Build status](https://badge.buildkite.com/977eb06da3ecf54e0e423fbe384892b27a265faefbfd69fa93.svg)](https://buildkite.com/helium/erlang-h3)
+![Build status](https://github.com/helium/erlang-h3/workflows/CI/badge.svg)
 [![codecov](https://codecov.io/gh/helium/erlang-h3/branch/master/graph/badge.svg)](https://codecov.io/gh/helium/erlang-h3)
 [![Hex.pm](https://img.shields.io/hexpm/v/h3)](https://hex.pm/packages/h3)
 


### PR DESCRIPTION
## Remaining

This doesn't work due to:

- [x] container missing codecov binary
- [x] needs `codecov` environment

Instead of just calling `make ci`, the workflow calls build, dialyze, and ct as separate tests. This will make it easier to tests with address sanitizer using the new functionaly coming in #14.