### PR TITLE
Use Helium's docker image for CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   CI:
     runs-on: ubuntu-latest
-    container: madninja/builder-erlang:2
+    container: helium/builder-erlang:1
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
#16 was meant to wait for our canonical docker image to switch to the Helium namespace, but I jumped the gun.