### PR TITLE
Force unshallow fetch in CI to avoid using hard-coded H3 tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Fetch git tags
+      run: git fetch --prune --unshallow --tags
+
     - name: Build
       env:
         SANITIZE_ERLANG_NIFS: 1


### PR DESCRIPTION
I thought I had pushed this to my previous PR but didn't.

[This line](https://github.com/helium/erlang-h3/pull/20/checks?check_run_id=861663250#step:5:20) in the build is what we want to see in CI and is the reason for this PR.