### PR TITLE
Enable cross-compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ need `cmake` installed to build the required h3 core package.
 
 To run the tests run `make test`.
 
+## Cross compilation
+
+Cross-compilation requires the environment variable `ERTS_INCLUDE_DIR`
+defined as the target directory containing `erl_nif.h`,
+e.g. `ERTS_INCLUDE_DIR=target/usr/lib/erlang/erts-<VERSION>/include`.
 
 Usage
 -----


### PR DESCRIPTION
This package can not be cross-compiled becuase uncondition execution of `erl` in `FindErlang.cmake`. To fix that problem, this PR:

1. Cuts down `FindErlang.cmake` to only what this library needs.
2. Skips `erl` execution if the semi-standard environment variable `ERTS_INCLUDE_DIR` is set.
