### PR TITLE
Modify contains/2 to perform zero-copy membership test on serialized indices

### DIFF
--- a/src/h3.erl
+++ b/src/h3.erl
@@ -202,13 +202,16 @@ set_to_multi_polygon(_) ->
 meminfo() ->
     not_loaded(?LINE).
 
-%% @doc Check if a list of H3 indices completely encompasses a target
-%% index.
+%% @doc Test if a `Set' of H3 indices completely encompasses a
+%%      `Target' H3 index.
+%%
+%% `Set' can be a list of H3 indices or a binary of serialized
+%% little-endian indices.
 %%
 %% Returns `{true, Index}' if the target is covered as the returned
 %% `Index' may be a parent to `Target'. Returns `false' is `Target' is
 %% not covered.
--spec contains(_Target::h3index(), _Set::[h3index(),...]) -> false | {true, h3index()}.
+-spec contains(Target::h3index(), Set::(binary() | [h3index(),...])) -> false | {true, h3index()}.
 contains(_Target, _Set) ->
     not_loaded(?LINE).
 


### PR DESCRIPTION
This patch modifies `contains/2` to perform zero-copy membership test on serialized indices. This allows checking a serialized binary with minimal overhead.

## Example

Test locations:

```erlang
1> TarponSprings = h3:from_geo({28.14209546931603, -82.75665097150251}, 12).
631702052826179071
2> DairyIsle = h3:from_geo({37.96648742360273, -91.36002165669227}, 12).
631177005232211967
3> Bimini = h3:from_geo({25.726864906131482, -79.29676154106401}, 12).
631711456926748159
4> Almont = h3:from_geo({46.72887827828476, -101.50349384893536}, 12).
631176215580036095
5> ClearwaterBeach = h3:from_geo({27.97380429905559, -82.83016590438804}, 12).
631702039300866559
6> SaltLakeCity = h3:from_geo({40.74839328820584, -111.88253094070544}, 12).
631182804769622015
7> BandarSeriBegawan = h3:from_geo({4.905792416533559, 114.93276723019176}, 12).
632335059112911359
8> TatshenshiniAlsekProvincialPark = h3:from_geo({59.702362050078506, -137.15257362745595}, 6).
603826531701096447
```

Read in a file of [serialized] little-endian H3 indices:

```erlang
9> {ok, Serialized} = file:read_file("path/to/lorawan-regions-h3/serialized/US915.res7.h3idx").
{ok,<<255,255,255,255,255,127,2,8,255,255,255,255,255,
      251,16,8,255,255,255,255,255,227,16,8,255,255,255,
      ...>>}
```

Perform membership tests:

```erlang
10> {_, {true, DairyIsleParent}} = timer:tc(fun() -> h3:contains(DairyIsle, Serialized) end).
{30,{true,577164439745200127}}
11> {_, {true, TarponSpringsParent}} = timer:tc(fun() -> h3:contains(TarponSprings, Serialized) end).
{38,{true,600176856263557119}}
12> {_, {true, AlmontParent}} = timer:tc(fun() -> h3:contains(Almont, Serialized) end).
{16,{true,577164439745200127}}
13> {_, {true, BiminiParent}} = timer:tc(fun() -> h3:contains(Bimini, Serialized) end).
{48,{true,600186260094451711}}
14> {_, {true, SaltLakeCityParent}} = timer:tc(fun() -> h3:contains(SaltLakeCity, Serialized) end).
{18,{true,577164439745200127}}
15> {_, {true, TatshenshiniAlsekProvincialParkParent}} = timer:tc(fun() -> h3:contains(TatshenshiniAlsekProvincialPark, Serialized) end).
{20,{true,590315767044505599}}
16> {_, false} = timer:tc(fun() -> h3:contains(BandarSeriBegawan, Serialized) end).
{374,false}
```

[serialized]: https://github.com/JayKickliter/lorawan-h3-regions/tree/main/serialized