### PR TITLE
Improve membership test perf

### DIFF
--- a/c_src/h3.c
+++ b/c_src/h3.c
@@ -1014,11 +1014,6 @@ erl_contains(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
                 | ((H3Index)le_idx[3] << 24) | ((H3Index)le_idx[2] << 16)
                 | ((H3Index)le_idx[1] << 8) | (H3Index)le_idx[0];
 
-            if (idx == key)
-            {
-                return enif_make_tuple2(env, ATOM_TRUE, argv[0]);
-            }
-
             int idx_res = h3GetResolution(idx);
 
             if ((idx_res < key_res) && (h3ToParent(key, idx_res) == idx))
@@ -1026,6 +1021,10 @@ erl_contains(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
                 return enif_make_tuple2(env,
                                         ATOM_TRUE,
                                         enif_make_uint64(env, idx));
+            }
+            else if (idx == key)
+            {
+                return enif_make_tuple2(env, ATOM_TRUE, argv[0]);
             }
         }
     }

--- a/c_src/h3.c
+++ b/c_src/h3.c
@@ -970,6 +970,27 @@ erl_contains(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
 
     int key_res = h3GetResolution(key);
 
+    /*
+     * In an effort to speed up membership tests in cache friendly
+     * manner, we pre-convert the key index at all possible H3 parent
+     * resolutions. Because it is only possible to convert a hex to
+     * rougher (lower res) parent index, all elements in the LUT that
+     * indices greater than the key are plain copies of the key.
+     */
+    H3Index key_res_lut[16];
+
+    for (int res = 0; res < 16; ++res)
+    {
+        if (res < key_res)
+        {
+            key_res_lut[res] = h3ToParent(key, res);
+        }
+        else
+        {
+            key_res_lut[res] = key;
+        }
+    }
+
     if (enif_is_list(env, argv[1]))
     {
         ERL_NIF_TERM list = argv[1];
@@ -984,14 +1005,9 @@ erl_contains(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
                 return enif_make_badarg(env);
             }
 
-            if (idx == key)
-            {
-                return enif_make_tuple2(env, ATOM_TRUE, argv[0]);
-            }
-
             int idx_res = h3GetResolution(idx);
 
-            if ((idx_res < key_res) && (h3ToParent(key, idx_res) == idx))
+            if (key_res_lut[idx_res] == idx)
             {
                 return enif_make_tuple2(env, ATOM_TRUE, head);
             }
@@ -1016,15 +1032,11 @@ erl_contains(ErlNifEnv * env, int argc, const ERL_NIF_TERM argv[])
 
             int idx_res = h3GetResolution(idx);
 
-            if ((idx_res < key_res) && (h3ToParent(key, idx_res) == idx))
+            if (key_res_lut[idx_res] == idx)
             {
                 return enif_make_tuple2(env,
                                         ATOM_TRUE,
                                         enif_make_uint64(env, idx));
-            }
-            else if (idx == key)
-            {
-                return enif_make_tuple2(env, ATOM_TRUE, argv[0]);
             }
         }
     }


### PR DESCRIPTION
This PR reduces branching and (hopefully) speeds up `contains/2` by pre-computing the key (index we're testing) at parent resolutions.

Non-rigorous testing indicates about a 2x speedup:

```erlang
{ok, US915} = file:read_file("/Users/jay/Downloads/US915.res7.h3idx"),
Paris = h3:from_geo({48.8566, 2.3522}, 12),
Apalachicola = h3:from_geo({29.7258, -84.9832}, 12),
{timer:tc(fun() -> h3:contains(Paris, US915) end), timer:tc(fun() -> h3:contains(Apalachicola, US915) end)}.
```

```
1> {ok, US915} = file:read_file("/Users/jay/Downloads/US915.res7.h3idx"),
1> Paris = h3:from_geo({48.8566, 2.3522}, 12),
1> Apalachicola = h3:from_geo({29.7258, -84.9832}, 12),
1> {timer:tc(fun() -> h3:contains(Paris, US915) end), timer:tc(fun() -> h3:contains(Apalachicola, US915) end)}.
{{395,false},{32,{true,595687121864359935}}}
2> {timer:tc(fun() -> h3:contains(Paris, US915) end), timer:tc(fun() -> h3:contains(Apalachicola, US915) end)}.
{{499,false},{34,{true,595687121864359935}}}
```

```
1> {ok, US915} = file:read_file("/Users/jay/Downloads/US915.res7.h3idx"),
1> Paris = h3:from_geo({48.8566, 2.3522}, 12),
1> Apalachicola = h3:from_geo({29.7258, -84.9832}, 12),
1> {timer:tc(fun() -> h3:contains(Paris, US915) end), timer:tc(fun() -> h3:contains(Apalachicola, US915) end)}.
{{154,false},{9,{true,595687121864359935}}}
2> {timer:tc(fun() -> h3:contains(Paris, US915) end), timer:tc(fun() -> h3:contains(Apalachicola, US915) end)}.
{{204,false},{14,{true,595687121864359935}}}
3> {timer:tc(fun() -> h3:contains(Paris, US915) end), timer:tc(fun() -> h3:contains(Apalachicola, US915) end)}.
{{181,false},{17,{true,595687121864359935}}}
```